### PR TITLE
Avoid empty STOW_DIR

### DIFF
--- a/bin/stow.in
+++ b/bin/stow.in
@@ -545,6 +545,12 @@ sub sanitize_path_options {
         $options->{dir} = exists $ENV{STOW_DIR} ? $ENV{STOW_DIR} : getcwd();
     }
 
+    # Do not allow empty stow dir
+    if (not length $options->{dir}) {
+        warn "STOW_DIR is empty, change stow dir to current directory";
+        $options->{dir} = '.';
+    }
+
     if (exists $options->{target}) {
         $options->{target} =~ s/\A +//;
         $options->{target} =~ s/ +\z//;


### PR DESCRIPTION
 - Empty STOW_DIR can lead to false positive, since when
 chdir('') change the working directory to $ENV{HOME}.
 - This commit fix the issue by setting stow dir to current
 directory if STOW_DIR is empty.