### PR TITLE
Allow directory with trailing and leading spaces

### DIFF
--- a/bin/stow.in
+++ b/bin/stow.in
@@ -537,11 +537,7 @@ sub process_options {
 sub sanitize_path_options {
     my ($options) = @_;
 
-    if (exists $options->{dir}) {
-        $options->{dir}    =~ s/\A +//;
-        $options->{dir}    =~ s/ +\z//;
-    }
-    else {
+    unless (exists $options->{dir}) {
         $options->{dir} = length $ENV{STOW_DIR} ? $ENV{STOW_DIR} : getcwd();
     }
 
@@ -549,8 +545,6 @@ sub sanitize_path_options {
         unless -d $options->{dir};
 
     if (exists $options->{target}) {
-        $options->{target} =~ s/\A +//;
-        $options->{target} =~ s/ +\z//;
         usage("--target value '$options->{target}' is not a valid directory")
             unless -d $options->{target};
     }

--- a/t/cli_options.t
+++ b/t/cli_options.t
@@ -17,8 +17,8 @@ init_test_dirs();
 
 local @ARGV = (
     '-v',
-    "-d $OUT_DIR/stow",
-    "-t $OUT_DIR/target",
+    '-d', "$OUT_DIR/stow",
+    '-t', "$OUT_DIR/target",
     'dummy'
 );
 


### PR DESCRIPTION
 - The `sanitize_path_options` functions remove all trailing
 and leading spaces. So any valid directory like `" 123"`,
 `"123" ` can not be used

 - Also if there are two directories `" 123"` and `"123"`, and if
 user pick the `" 123"` as option to `-d` or `-t`, then stow pick
 directory `"123"` as the argument instead of `" 123"` as user want.

    ```
    $ STOW_DIR=. stow -n -v3 -t \ 123 456
    stow dir is /tmp/test
    stow dir path relative to target 123 is ..
    cwd now 123
    cwd restored to /tmp/test
    cwd now 123
    Planning stow of package 456...
    Stowing contents of ../456 (cwd=/tmp/test/123)
    Planning stow of package 456... done
    cwd restored to /tmp/test
    WARNING: in simulation mode so not modifying filesystem.
    ```
 - This commit remove the check in `sanitize_path_options` function,
 and now stow can work with those directories. There have been a check
 for valid directory, so we are safe.