### PR TITLE
Added docker files for local testing.

### DIFF
--- a/MANIFEST.SKIP
+++ b/MANIFEST.SKIP
@@ -83,3 +83,5 @@
 # Avoid test files
 tmp-testing-trees
 .travis.yml
+^docker/
+^[a-zA-Z]*-docker.sh

--- a/build-docker.sh
+++ b/build-docker.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+set -eu
+
+pushd docker
+docker build -t stowtest .
+popd

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,0 +1,47 @@
+# Build docker image: `docker build -t stowtest`
+# Run tests: (from stow src directory) 
+#    `docker run --rm -it -v $(pwd):$(pwd) -w $(pwd) stowtest`
+FROM debian:jessie
+RUN DEBIAN_FRONTEND=noninteractive \
+apt-get clean && \
+apt-get update -qq && \
+apt-get install -y -q \
+    autoconf \
+    bzip2 \
+    cpanminus \
+    gawk \
+    git \
+	libssl-dev \
+    make \
+	patch \
+    perlbrew \
+    texinfo \
+    texlive \
+    texi2html \
+&& rm -rf /var/lib/apt/lists/*
+
+# Set up perlbrew
+ENV HOME=/root \
+    PERLBREW_ROOT=/usr/local/perlbrew \
+    PERLBREW_HOME=/root/.perlbrew \
+    PERLBREW_PATH=/usr/local/perlbrew/bin
+RUN mkdir -p /usr/local/perlbrew /root \
+    && perlbrew init \
+	&& perlbrew install-cpanm \
+	&& perlbrew install-patchperl \
+    && perlbrew install-multiple -j 4 --notest \
+        perl-5.22.2 \
+        perl-5.20.3 \
+        perl-5.18.4 \
+        perl-5.16.3 \
+        perl-5.14.4 \
+&& perlbrew clean
+
+# Bootstrap the perl environments
+COPY ./bootstrap-perls.sh /bootstrap-perls.sh
+RUN /bootstrap-perls.sh && rm /bootstrap-perls.sh
+
+# Add test script to container filesystem
+COPY ./run-stow-tests.sh /run-stow-tests.sh
+
+ENTRYPOINT ["/run-stow-tests.sh"]

--- a/docker/bootstrap-perls.sh
+++ b/docker/bootstrap-perls.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+
+# Load perlbrew environment
+. /usr/local/perlbrew/etc/bashrc
+
+# For each perl version installed.
+for p_version in $(perlbrew list | sed 's/ //g'); do
+    # Switch to it.
+    perlbrew use $p_version 
+    # and install the needed modules.
+ 	/usr/local/perlbrew/bin/cpanm -n Devel::Cover::Report::Coveralls Test::More Test::Output
+done
+
+# Cleanup to remove any temp files. 
+perlbrew clean

--- a/docker/run-stow-tests.sh
+++ b/docker/run-stow-tests.sh
@@ -1,0 +1,31 @@
+#!/bin/bash
+
+# Load perlbrew environment
+# Load before setting safety to keep
+# perlbrew scripts from breaking due to
+# unset variables.
+. /usr/local/perlbrew/etc/bashrc
+
+# Standard safety protocol
+set -euf -o pipefail
+IFS=$'\n\t'
+
+for p_version in $(perlbrew list | sed 's/ //g'); do
+
+    perlbrew use $p_version
+
+    echo $(perl --version)
+
+    # Install stow
+    autoreconf --install 
+	eval `perl -V:siteprefix`
+	./configure --prefix=$siteprefix && make
+	make cpanm
+
+    # Run tests
+    make distcheck 
+	perl Build.PL && ./Build build && cover -test
+	./Build distcheck
+done
+
+make distclean

--- a/test-docker.sh
+++ b/test-docker.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+# Run the docker image that test. 
+docker run --rm -it -v $(pwd):$(pwd) -w $(pwd) stowtest


### PR DESCRIPTION
* Use docker to locally run tests on multiple perl versions
    * perlbrew used to install multiple perls
    * perl environments bootstrapped when image built
* Based on travis configuration
* Adds docker folder to MANIFEST.SKIP
* Running image runs all tests.
    * If exit with no error, then all tests pass.
* ./build-docker.sh builds stow testing image.
* ./test-docker.sh runs stow testing image.
    * Assumes built with options in build-docker.sh
* *-docker.sh scripts added to MANIFEST.SKIP