### PR TITLE
make chkstow honour $STOW_DIR environment variable

### DIFF
--- a/THANKS
+++ b/THANKS
@@ -31,6 +31,7 @@ Kristoffer Haugsbakk
 Hongyi Zhao
 Jean Louis
 Daniel Shahaf
+Matan Nassau
 
 Email addresses of new contributors are no longer being added by default
 for privacy reasons; however please contact the maintainer if you are

--- a/bin/chkstow.in
+++ b/bin/chkstow.in
@@ -8,7 +8,7 @@ require 5.006_001;
 use File::Find;
 use Getopt::Long;
 
-my $DEFAULT_TARGET = '/usr/local/';
+my $DEFAULT_TARGET = $ENV{STOW_DIR} || '/usr/local/';
 
 our $Wanted   = \&bad_links;
 our %Package  = ();


### PR DESCRIPTION
Thanks to Matan Nassau for reporting this deficiency.