### PR TITLE
Avoid dereferencing $ENV{HOME} if it is undefined

### DIFF
--- a/bin/stow.in
+++ b/bin/stow.in
@@ -598,7 +598,11 @@ sub check_packages {
 #=============================================================================
 sub get_config_file_options {
     my @defaults = ();
-    for my $file ("$ENV{HOME}/.stowrc", '.stowrc') {
+    my @dirlist = ('.stowrc');
+    if (defined($ENV{HOME})) {
+        unshift(@dirlist, "$ENV{HOME}/.stowrc");
+    }
+    for my $file (@dirlist) {
         if (-r $file) {
             warn "Loading defaults from $file\n";
             open my $FILE, '<', $file


### PR DESCRIPTION
If the HOME environment variable is not defined, Stow will throw warnings along the lines of:

    Use of uninitialized value $ENV{"HOME"} in concatenation(.) or string at /usr/bin/stow line 590, <DATA> line 18.

because it assembles the string `$ENV{HOME}/.stowrc`. This patch avoids dereferencing `$ENV{HOME}` if it is not defined.

I've had this change in production on our systems for a while because a piece of automation doesn't set HOME before invoking `stow`.