### PR TITLE
return exit code 1 when unknown option 

### DIFF
--- a/bin/stow.in
+++ b/bin/stow.in
@@ -539,7 +539,7 @@ sub process_options {
                 push @pkgs_to_stow, $_[0];
             }
         },
-    ) or usage();
+    ) or usage(0);
 
     usage()   if $options{help};
     version() if $options{version};

--- a/build-docker.sh
+++ b/build-docker.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -eu
 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -3,7 +3,6 @@
 #    `docker run --rm -it -v $(pwd):$(pwd) -w $(pwd) stowtest`
 FROM debian:jessie
 RUN DEBIAN_FRONTEND=noninteractive \
-apt-get clean && \
 apt-get update -qq && \
 apt-get install -y -q \
     autoconf \
@@ -18,6 +17,7 @@ apt-get install -y -q \
     texinfo \
     texlive \
     texi2html \
+&& apt-get clean \
 && rm -rf /var/lib/apt/lists/*
 
 # Set up perlbrew

--- a/test-docker.sh
+++ b/test-docker.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # Test Stow across multiple Perl versions, by executing the
 # Docker image built via build-docker.sh.


### PR DESCRIPTION
Fixes #34, I din't write the test that goes along because it would have needed to pull a new dependency ([Test::Exit](https://metacpan.org/pod/Test::Exit)) just for it.

There is also 2 minor changes I had to do to build to build the project correctly on NixOS, namely:
- making the scripts running outside of docker more portable
- fixing the Dockerfile