### PR TITLE
Fix Travis failure after merging #42

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,6 @@ addons:
     packages:
     - texinfo
     - texlive
-    - texi2html
 before_install:
   - cpanm -n Devel::Cover::Report::Coveralls
 install:


### PR DESCRIPTION
Something weird happened with
https://travis-ci.org/aspiers/stow/jobs/551290921 after merging #42,
as shown below.  Maybe removing texi2html from the list of packages
for Travis to install will help.

```
Installing APT Packages
15.50s$ travis_apt_get_update
0.11s$ sudo -E apt-get -yq --no-install-suggests --no-install-recommends $(travis_apt_get_options) install texinfo texlive texi2html
Reading package lists...
Building dependency tree...
Reading state information...
Package texinfo is not available, but is referred to by another package.
This may mean that the package is missing, has been obsoleted, or
is only available from another source
However the following packages replace it:
  info install-info
E: Package 'texinfo' has no installation candidate
E: Unable to locate package texi2html
apt-get.diagnostics
apt-get install failed
$ cat ${TRAVIS_HOME}/apt-get-update.log
Get:2 http://dl.hhvm.com/ubuntu trusty InRelease [3,106 B]
Get:3 http://security.ubuntu.com/ubuntu trusty-security InRelease [65.9 kB]
Get:4 http://ppa.launchpad.net/chris-lea/redis-server/ubuntu trusty InRelease [15.4 kB]
Ign:5 http://repo.mongodb.org/apt/ubuntu trusty/mongodb-org/3.4 InRelease
Get:6 http://repo.mongodb.org/apt/ubuntu trusty/mongodb-org/3.4 Release [2,495 B]
Get:7 http://repo.mongodb.org/apt/ubuntu trusty/mongodb-org/3.4 Release.gpg [801 B]
Get:8 http://dl.hhvm.com/ubuntu trusty/main amd64 Packages [1,812 B]
Get:9 http://security.ubuntu.com/ubuntu trusty-security/main Sources [220 kB]
Get:10 http://security.ubuntu.com/ubuntu trusty-security/restricted Sources [5,050 B]
Get:11 http://security.ubuntu.com/ubuntu trusty-security/universe Sources [126 kB]
Get:12 http://security.ubuntu.com/ubuntu trusty-security/multiverse Sources [3,070 B]
Get:13 http://security.ubuntu.com/ubuntu trusty-security/main amd64 Packages [1,032 kB]
Get:14 http://security.ubuntu.com/ubuntu trusty-security/main i386 Packages [934 kB]
Get:15 http://security.ubuntu.com/ubuntu trusty-security/main Translation-en [541 kB]
Get:16 http://security.ubuntu.com/ubuntu trusty-security/restricted amd64 Packages [18.1 kB]
Get:17 http://security.ubuntu.com/ubuntu trusty-security/restricted i386 Packages [17.8 kB]
Get:18 http://security.ubuntu.com/ubuntu trusty-security/restricted Translation-en [3,272 B]
Get:19 http://security.ubuntu.com/ubuntu trusty-security/universe amd64 Packages [377 kB]
Get:20 http://security.ubuntu.com/ubuntu trusty-security/universe i386 Packages [355 kB]
Get:21 http://security.ubuntu.com/ubuntu trusty-security/universe Translation-en [203 kB]
Get:22 http://security.ubuntu.com/ubuntu trusty-security/multiverse amd64 Packages [4,730 B]
Get:23 http://security.ubuntu.com/ubuntu trusty-security/multiverse i386 Packages [4,887 B]
Get:24 http://security.ubuntu.com/ubuntu trusty-security/multiverse Translation-en [2,426 B]
Get:25 https://download.docker.com/linux/ubuntu trusty InRelease [37.1 kB]
Get:26 http://repo.mongodb.org/apt/ubuntu trusty/mongodb-org/3.4/multiverse amd64 Packages [14.1 kB]
Get:27 https://download.docker.com/linux/ubuntu trusty/stable amd64 Packages [5,763 B]
Get:28 https://download.docker.com/linux/ubuntu trusty/edge amd64 Packages [6,911 B]
Ign:29 http://ppa.launchpad.net/couchdb/stable/ubuntu trusty InRelease
Get:30 http://ppa.launchpad.net/git-core/ppa/ubuntu trusty InRelease [20.8 kB]
Get:31 http://ppa.launchpad.net/hvr/ghc/ubuntu trusty InRelease [15.4 kB]
Get:32 http://ppa.launchpad.net/pollinate/ppa/ubuntu trusty InRelease [15.4 kB]
Get:33 http://ppa.launchpad.net/webupd8team/java/ubuntu trusty InRelease [15.5 kB]
Get:34 http://ppa.launchpad.net/chris-lea/redis-server/ubuntu trusty/main amd64 Packages [1,843 B]
Get:35 http://ppa.launchpad.net/chris-lea/redis-server/ubuntu trusty/main i386 Packages [1,842 B]
Get:36 http://ppa.launchpad.net/chris-lea/redis-server/ubuntu trusty/main Translation-en [990 B]
Get:37 http://ppa.launchpad.net/couchdb/stable/ubuntu trusty Release [15.1 kB]
Get:38 http://ppa.launchpad.net/couchdb/stable/ubuntu trusty Release.gpg [316 B]
Ign:39 http://dl.google.com/linux/chrome/deb stable InRelease
Get:40 http://dl.google.com/linux/chrome/deb stable Release [943 B]
Get:41 http://dl.google.com/linux/chrome/deb stable Release.gpg [819 B]
Get:42 http://ppa.launchpad.net/git-core/ppa/ubuntu trusty/main amd64 Packages [3,494 B]
Get:43 http://ppa.launchpad.net/git-core/ppa/ubuntu trusty/main i386 Packages [3,496 B]
Get:44 http://ppa.launchpad.net/git-core/ppa/ubuntu trusty/main Translation-en [2,368 B]
Get:45 http://ppa.launchpad.net/hvr/ghc/ubuntu trusty/main amd64 Packages [18.5 kB]
Get:46 http://ppa.launchpad.net/hvr/ghc/ubuntu trusty/main i386 Packages [15.7 kB]
Get:47 http://ppa.launchpad.net/hvr/ghc/ubuntu trusty/main Translation-en [1,107 B]
Get:48 http://ppa.launchpad.net/pollinate/ppa/ubuntu trusty/main amd64 Packages [430 B]
Get:49 http://ppa.launchpad.net/pollinate/ppa/ubuntu trusty/main i386 Packages [430 B]
Get:50 http://ppa.launchpad.net/pollinate/ppa/ubuntu trusty/main Translation-en [374 B]
Get:51 http://ppa.launchpad.net/webupd8team/java/ubuntu trusty/main amd64 Packages [20 B]
Get:52 http://ppa.launchpad.net/webupd8team/java/ubuntu trusty/main i386 Packages [20 B]
Get:53 http://ppa.launchpad.net/webupd8team/java/ubuntu trusty/main Translation-en [20 B]
Get:54 http://ppa.launchpad.net/couchdb/stable/ubuntu trusty/main amd64 Packages [985 B]
Get:55 http://ppa.launchpad.net/couchdb/stable/ubuntu trusty/main i386 Packages [985 B]
Get:56 http://ppa.launchpad.net/couchdb/stable/ubuntu trusty/main Translation-en [644 B]
Get:57 http://dl.google.com/linux/chrome/deb stable/main amd64 Packages [1,107 B]
Err:58 https://packagecloud.io/computology/apt-backport/ubuntu trusty InRelease
  Failed to connect to packagecloud.io port 443: Connection timed out
Err:59 http://us-east-1.ec2.archive.ubuntu.com/ubuntu trusty InRelease
  Could not connect to apt.cache.travis-ci.com:80 (34.96.81.152), connection timed out
Err:60 http://us-east-1.ec2.archive.ubuntu.com/ubuntu trusty-updates InRelease
  Unable to connect to apt.cache.travis-ci.com:http:
Err:61 http://toolbelt.heroku.com/ubuntu ./ InRelease
  Could not connect to apt.cache.travis-ci.com:80 (34.96.81.152), connection timed out
Err:62 http://us-east-1.ec2.archive.ubuntu.com/ubuntu trusty-backports InRelease
  Unable to connect to apt.cache.travis-ci.com:http:
Err:63 http://apt.postgresql.org/pub/repos/apt trusty-pgdg InRelease
  Could not connect to apt.cache.travis-ci.com:80 (34.96.81.152), connection timed out
Err:1 http://dl.bintray.com/apache/cassandra 39x InRelease
  Could not connect to apt.cache.travis-ci.com:80 (34.96.81.152), connection timed out
Get:64 https://packagecloud.io/github/git-lfs/ubuntu trusty InRelease [23.2 kB]
Ign:64 https://packagecloud.io/github/git-lfs/ubuntu trusty InRelease
Get:65 https://packagecloud.io/rabbitmq/rabbitmq-server/ubuntu trusty InRelease [23.7 kB]
Get:66 https://packagecloud.io/github/git-lfs/ubuntu trusty/main Sources [20 B]
Get:67 https://packagecloud.io/github/git-lfs/ubuntu trusty/main amd64 Packages [8,003 B]
Get:68 https://packagecloud.io/github/git-lfs/ubuntu trusty/main i386 Packages [7,761 B]
Get:69 https://packagecloud.io/rabbitmq/rabbitmq-server/ubuntu trusty/main Sources [20 B]
Get:70 https://packagecloud.io/rabbitmq/rabbitmq-server/ubuntu trusty/main amd64 Packages [7,866 B]
Get:71 https://packagecloud.io/rabbitmq/rabbitmq-server/ubuntu trusty/main i386 Packages [7,866 B]
Fetched 4,218 kB in 15s (279 kB/s)
Reading package lists...
W: http://ppa.launchpad.net/couchdb/stable/ubuntu/dists/trusty/Release.gpg: Signature by key 15866BAFD9BCC4F3C1E0DFC7D69548E1C17EAB57 uses weak digest algorithm (SHA1)
W: GPG error: https://packagecloud.io/github/git-lfs/ubuntu trusty InRelease: The following signatures couldn't be verified because the public key is not available: NO_PUBKEY 6B05F25D762E3157
W: The repository 'https://packagecloud.io/github/git-lfs/ubuntu trusty InRelease' is not signed.
W: There is no public key available for the following key IDs:
6B05F25D762E3157
W: Failed to fetch http://us-east-1.ec2.archive.ubuntu.com/ubuntu/dists/trusty/InRelease  Could not connect to apt.cache.travis-ci.com:80 (34.96.81.152), connection timed out
W: Failed to fetch http://us-east-1.ec2.archive.ubuntu.com/ubuntu/dists/trusty-updates/InRelease  Unable to connect to apt.cache.travis-ci.com:http:
W: Failed to fetch http://us-east-1.ec2.archive.ubuntu.com/ubuntu/dists/trusty-backports/InRelease  Unable to connect to apt.cache.travis-ci.com:http:
W: Failed to fetch http://www.apache.org/dist/cassandra/debian/dists/39x/InRelease  Could not connect to apt.cache.travis-ci.com:80 (34.96.81.152), connection timed out
W: Failed to fetch https://packagecloud.io/computology/apt-backport/ubuntu/dists/trusty/InRelease  Failed to connect to packagecloud.io port 443: Connection timed out
W: Failed to fetch http://toolbelt.heroku.com/ubuntu/./InRelease  Could not connect to apt.cache.travis-ci.com:80 (34.96.81.152), connection timed out
W: Failed to fetch http://apt.postgresql.org/pub/repos/apt/dists/trusty-pgdg/InRelease  Could not connect to apt.cache.travis-ci.com:80 (34.96.81.152), connection timed out
W: Some index files failed to download. They have been ignored, or old ones used instead.
The command "sudo -E apt-get -yq --no-install-suggests --no-install-recommends $(travis_apt_get_options) install texinfo texlive texi2html" failed and exited with 100 during .
Your build has been stopped.
```