### PR TITLE
Remove dependencies on Hash::Merge and Clone::Choose

### DIFF
--- a/Build.PL
+++ b/Build.PL
@@ -60,8 +60,6 @@ my $build = Module::Build->new(
         'perl'        => '5.006',
         'Carp'        => 0,
         'IO::File'    => 0,
-        'Hash::Merge' => 0,
-        'Clone'       => 0,
     },
     script_files => [ 'bin/stow', 'bin/chkstow' ],
     all_from => 'lib/Stow.pm.in',

--- a/META.json
+++ b/META.json
@@ -29,8 +29,6 @@
       "runtime" : {
          "requires" : {
             "Carp" : "0",
-            "Clone" : "0",
-            "Hash::Merge" : "0",
             "IO::File" : "0",
             "perl" : "5.006"
          }

--- a/META.json
+++ b/META.json
@@ -39,11 +39,11 @@
    "provides" : {
       "Stow" : {
          "file" : "lib/Stow.pm",
-         "version" : "v2.3.0"
+         "version" : "v2.3.1"
       },
       "Stow::Util" : {
          "file" : "lib/Stow/Util.pm",
-         "version" : "v2.3.0"
+         "version" : "v2.3.1"
       }
    },
    "release_status" : "stable",
@@ -57,6 +57,6 @@
          "url" : "git://git.savannah.gnu.org/stow.git"
       }
    },
-   "version" : "v2.3.0",
+   "version" : "v2.3.1",
    "x_serialization_backend" : "JSON::PP version 4.00"
 }

--- a/META.yml
+++ b/META.yml
@@ -24,8 +24,6 @@ provides:
     version: v2.3.1
 requires:
   Carp: '0'
-  Clone: '0'
-  Hash::Merge: '0'
   IO::File: '0'
   perl: '5.006'
 resources:

--- a/META.yml
+++ b/META.yml
@@ -18,10 +18,10 @@ name: Stow
 provides:
   Stow:
     file: lib/Stow.pm
-    version: v2.3.0
+    version: v2.3.1
   Stow::Util:
     file: lib/Stow/Util.pm
-    version: v2.3.0
+    version: v2.3.1
 requires:
   Carp: '0'
   Clone: '0'
@@ -32,5 +32,5 @@ resources:
   homepage: https://savannah.gnu.org/projects/stow
   license: http://www.gnu.org/licenses/gpl-2.0.html
   repository: git://git.savannah.gnu.org/stow.git
-version: v2.3.0
+version: v2.3.1
 x_serialization_backend: 'CPAN::Meta::YAML version 0.018'

--- a/NEWS
+++ b/NEWS
@@ -2,6 +2,25 @@ News file for Stow.
 
 * Changes in version 2.3.1
 
+*** Remove dependencies on Hash::Merge and Clone::Choose
+
+    stow 2.3.0 added external runtime dependencies on Hash::Merge and
+    Clone::Choose. Historically stow hasn't had runtime dependencies
+    other than Perl itself, which is a useful property if you're
+    managing the installation of Perl using stow; the bootstrapping
+    instructions in stow's manual would need updating to describe how
+    to install these two modules (and any dependencies they have now
+    or in the future) as well.
+
+    However, Hash::Merge is much more general than stow actually
+    needs, so replace the merge() call with a few lines of equivalent
+    code -- this avoids the external dependencies, and is clearer than
+    the merge() call.
+
+    Many thanks to Adam Sampson for this patch!
+
+    https://lists.gnu.org/archive/html/bug-stow/2019-06/msg00001.html
+
 * Changes in version 2.3.0
 
 *** New features / changes in behaviour

--- a/NEWS
+++ b/NEWS
@@ -1,5 +1,7 @@
 News file for Stow.
 
+* Changes in version 2.3.1
+
 * Changes in version 2.3.0
 
 *** New features / changes in behaviour

--- a/bin/stow.in
+++ b/bin/stow.in
@@ -457,15 +457,11 @@ require 5.006_001;
 
 use POSIX qw(getcwd);
 use Getopt::Long qw(GetOptionsFromArray);
+use Scalar::Util qw(reftype);
 
 @USE_LIB_PMDIR@
 use Stow;
 use Stow::Util qw(parent error);
-
-# Need to avoid Storable backend, since it can't deal with regexps:
-# https://rt.perl.org/Public/Bug/Display.html?id=50608
-use Clone::Choose qw(:Clone);
-use Hash::Merge qw(merge);
 
 my $ProgramName = $0;
 $ProgramName =~ s{.*/}{};
@@ -530,17 +526,27 @@ sub process_options {
 
     # Merge .stowrc and command line options.
     # Preference is given to cli options.
-    # rc options come first in merged arrays.
-    # cli options overwrite conflicting rc options.
-    Hash::Merge::set_behavior('RIGHT_PRECEDENT');
-    my $options = merge($rc_options, $cli_options);
+    my %options = %$rc_options;
+    foreach my $option (keys %$cli_options) {
+        my $rc_value = $rc_options->{$option};
+        my $cli_value = $cli_options->{$option};
+        my $type = reftype($cli_value);
+
+        if (defined $type && $type eq 'ARRAY' && defined $rc_value) {
+            # rc options come first in merged arrays.
+            $options{$option} = [@{$rc_value}, @{$cli_value}];
+        } else {
+            # cli options overwrite conflicting rc options.
+            $options{$option} = $cli_value;
+        }
+    }
 
     # Run checks on the merged options.
-    sanitize_path_options($options);
+    sanitize_path_options(\%options);
     check_packages($pkgs_to_unstow, $pkgs_to_stow);
 
     # Return merged and processed options.
-    return ($options, $pkgs_to_unstow, $pkgs_to_stow);
+    return (\%options, $pkgs_to_unstow, $pkgs_to_stow);
 }
 
 #===== SUBROUTINE ===========================================================

--- a/configure.ac
+++ b/configure.ac
@@ -15,7 +15,7 @@ dnl along with this program. If not, see https://www.gnu.org/licenses/.
 
 dnl Process this file with Autoconf to produce configure dnl
 
-AC_INIT([stow], [2.3.0], [bug-stow@gnu.org])
+AC_INIT([stow], [2.3.1], [bug-stow@gnu.org])
 AC_PREREQ([2.61])
 AC_CONFIG_AUX_DIR([automake])
 # Unfortunately we have to disable warnings for overrides, because we

--- a/doc/HOWTO-RELEASE
+++ b/doc/HOWTO-RELEASE
@@ -140,10 +140,14 @@ Release procedure
 
     - Increment the patchlevel of the version number in configure.ac.
 
+    - Run this again:
+
+        version=$( tools/get-version ) && echo $version
+
     - Repeat the same procedure listed in the Module::Build section
       above, in order to update META.yaml and META.json.
 
-    - git commit -m "Bump version to X.Y.Z for development of next release"
+    - git commit -m "Bump version to $version for development of next release"
 
     - git push savannah
 

--- a/t/rc_options.t
+++ b/t/rc_options.t
@@ -22,7 +22,7 @@
 use strict;
 use warnings;
 
-use Test::More tests => 33;
+use Test::More tests => 34;
 
 use testutil;
 
@@ -120,16 +120,19 @@ is($options->{dir}, "$ABS_TEST_DIR/stow"
    => "-d from \$HOME/.stowrc");
 
 #
-# Test ~/.stowrc file is overridden by .stowrc in cwd.
+# Test that some but not all options ~/.stowrc file are overridden by
+# .stowrc in cwd.
 #
 local @ARGV = ('dummy');
 make_file($HOME_RC_FILE, <<HERE);
     -d $ABS_TEST_DIR/stow-will-be-overridden
     --target $ABS_TEST_DIR/target-will-be-overridden
+    --defer=info
 HERE
 make_file($CWD_RC_FILE, <<HERE);
     -d $ABS_TEST_DIR/stow
     --target $ABS_TEST_DIR/target
+    --defer=man
 HERE
 
 ($options, $pkgs_to_delete, $pkgs_to_stow) = process_options();
@@ -137,6 +140,8 @@ is($options->{target},  "$ABS_TEST_DIR/target"
    => "--target overridden by \$PWD/.stowrc");
 is($options->{dir}, "$ABS_TEST_DIR/stow"
    => "-d overridden \$PWD/.stowrc");
+is_deeply($options->{defer}, [qr(\Ainfo), qr(\Aman)],
+          'defer man and info');
 unlink($CWD_RC_FILE) or die "Failed to unlink $CWD_RC_FILE";
 
 #


### PR DESCRIPTION
stow 2.3.0 added external runtime dependencies on Hash::Merge and
Clone::Choose. Historically stow hasn't had runtime dependencies other
than Perl itself, which is a useful property if you're managing the
installation of Perl using stow; the bootstrapping instructions in
stow's manual would need updating to describe how to install these two
modules (and any dependencies they have now or in the future) as well.

However, Hash::Merge is much more general than stow actually needs, so
replace the merge() call with a few lines of equivalent code -- this
avoids the external dependencies, and is clearer than the merge()
call.

Many thanks to Adam Sampson for this patch:

https://lists.gnu.org/archive/html/bug-stow/2019-06/msg00001.html