### PR TITLE
cli.t: test with the right Perl executable

### DIFF
--- a/THANKS
+++ b/THANKS
@@ -36,6 +36,7 @@ Jean Louis
 Daniel Shahaf
 Matan Nassau
 Brice Waegeneire
+Slaven Rezic
 
 Email addresses of new contributors are no longer being added by default
 for privacy reasons; however please contact the maintainer if you are

--- a/t/cli.t
+++ b/t/cli.t
@@ -57,7 +57,7 @@ use testutil;
 #
 # or from the top of the source tree during development.  This can be done
 # via the following, which also follows the KISS principle:
-my $STOW = 'bin/stow';
+my $STOW = "$^X bin/stow";
 
 `$STOW --help`;
 is($?, 0, "--help should return 0 exit code");


### PR DESCRIPTION
`t/cli.t` calls scripts which run with the first perl found in the user's `PATH` (usually the system perl), not with the perl used for the build, as reported here:

- https://rt.cpan.org/Ticket/Display.html?id=129944

Thanks to Slaven Rezic for spotting this and reporting it!