### PR TITLE
Keep track of adjusted and original dotfile paths

### DIFF
--- a/lib/Stow.pm.in
+++ b/lib/Stow.pm.in
@@ -369,16 +369,16 @@ sub stow_contents {
     my $self = shift;
     my ($stow_path, $package, $package_target, $source) = @_;
 
-    my $real_target = $package_target;
+    my $target = $package_target;
 
     if ($self->{dotfiles}) {
-        debug(4, "  Adjusting: $package_target => $real_target");
-        $real_target = adjust_dotfile($package_target);
+        debug(4, "  Adjusting: $package_target => $target");
+        $target = adjust_dotfile($package_target);
     }
 
     my $path = join_paths($stow_path, $package, $package_target);
 
-    return if $self->should_skip_target_which_is_stow_dir($real_target);
+    return if $self->should_skip_target_which_is_stow_dir($target);
 
     my $cwd = getcwd();
     my $msg = "Stowing contents of $path (cwd=$cwd)";
@@ -388,8 +388,8 @@ sub stow_contents {
 
     error("stow_contents() called with non-directory path: $path")
         unless -d $path;
-    error("stow_contents() called with non-directory target: $real_target")
-        unless $self->is_a_node($real_target);
+    error("stow_contents() called with non-directory target: $target")
+        unless $self->is_a_node($target);
 
     opendir my $DIR, $path
         or error("cannot read directory: $path ($!)");
@@ -432,11 +432,11 @@ sub stow_node {
     my $self = shift;
     my ($stow_path, $package, $package_target, $source) = @_;
 
-    my $real_target = $package_target;
+    my $target = $package_target;
 
     if ($self->{dotfiles}) {
-        debug(4, "  Adjusting: $package_target => $real_target");
-        $real_target = adjust_dotfile($package_target);
+        debug(4, "  Adjusting: $package_target => $target");
+        $target = adjust_dotfile($package_target);
     }
 
     my $path = join_paths($stow_path, $package, $package_target);
@@ -459,49 +459,49 @@ sub stow_node {
     }
 
     # Does the target already exist?
-    if ($self->is_a_link($real_target)) {
+    if ($self->is_a_link($target)) {
         # Where is the link pointing?
-        my $existing_source = $self->read_a_link($real_target);
+        my $existing_source = $self->read_a_link($target);
         if (not $existing_source) {
-            error("Could not read link: $real_target");
+            error("Could not read link: $target");
         }
-        debug(4, "  Evaluate existing link: $real_target => $existing_source");
+        debug(4, "  Evaluate existing link: $target => $existing_source");
 
         # Does it point to a node under any stow directory?
         my ($existing_path, $existing_stow_path, $existing_package) =
-            $self->find_stowed_path($real_target, $existing_source);
+            $self->find_stowed_path($target, $existing_source);
         if (not $existing_path) {
             $self->conflict(
                 'stow',
                 $package,
-                "existing target is not owned by stow: $real_target"
+                "existing target is not owned by stow: $target"
             );
             return; # XXX #
         }
 
-        # Does the existing $real_target actually point to anything?
+        # Does the existing $target actually point to anything?
         if ($self->is_a_node($existing_path)) {
             if ($existing_source eq $source) {
-                debug(2, "--- Skipping $real_target as it already points to $source");
+                debug(2, "--- Skipping $target as it already points to $source");
             }
-            elsif ($self->defer($real_target)) {
-                debug(2, "--- Deferring installation of: $real_target");
+            elsif ($self->defer($target)) {
+                debug(2, "--- Deferring installation of: $target");
             }
-            elsif ($self->override($real_target)) {
-                debug(2, "--- Overriding installation of: $real_target");
-                $self->do_unlink($real_target);
-                $self->do_link($source, $real_target);
+            elsif ($self->override($target)) {
+                debug(2, "--- Overriding installation of: $target");
+                $self->do_unlink($target);
+                $self->do_link($source, $target);
             }
-            elsif ($self->is_a_dir(join_paths(parent($real_target), $existing_source)) &&
-                   $self->is_a_dir(join_paths(parent($real_target), $source))     ) {
+            elsif ($self->is_a_dir(join_paths(parent($target), $existing_source)) &&
+                   $self->is_a_dir(join_paths(parent($target), $source))     ) {
 
                 # If the existing link points to a directory,
                 # and the proposed new link points to a directory,
                 # then we can unfold (split open) the tree at that point
 
-                debug(2, "--- Unfolding $real_target which was already owned by $existing_package");
-                $self->do_unlink($real_target);
-                $self->do_mkdir($real_target);
+                debug(2, "--- Unfolding $target which was already owned by $existing_package");
+                $self->do_unlink($target);
+                $self->do_mkdir($target);
                 $self->stow_contents(
                     $existing_stow_path,
                     $existing_package,
@@ -520,20 +520,20 @@ sub stow_node {
                     'stow',
                     $package,
                     "existing target is stowed to a different package: "
-                    . "$real_target => $existing_source"
+                    . "$target => $existing_source"
                 );
             }
         }
         else {
             # The existing link is invalid, so replace it with a good link
             debug(2, "--- replacing invalid link: $path");
-            $self->do_unlink($real_target);
-            $self->do_link($source, $real_target);
+            $self->do_unlink($target);
+            $self->do_link($source, $target);
         }
     }
-    elsif ($self->is_a_node($real_target)) {
-        debug(4, "  Evaluate existing node: $real_target");
-        if ($self->is_a_dir($real_target)) {
+    elsif ($self->is_a_node($target)) {
+        debug(4, "  Evaluate existing node: $target");
+        if ($self->is_a_dir($target)) {
             $self->stow_contents(
                 $self->{stow_path},
                 $package,
@@ -543,20 +543,20 @@ sub stow_node {
         }
         else {
             if ($self->{adopt}) {
-                $self->do_mv($real_target, $path);
-                $self->do_link($source, $real_target);
+                $self->do_mv($target, $path);
+                $self->do_link($source, $target);
             }
             else {
                 $self->conflict(
                     'stow',
                     $package,
-                    "existing target is neither a link nor a directory: $real_target"
+                    "existing target is neither a link nor a directory: $target"
                 );
             }
         }
     }
     elsif ($self->{'no-folding'} && -d $path && ! -l $path) {
-        $self->do_mkdir($real_target);
+        $self->do_mkdir($target);
         $self->stow_contents(
             $self->{stow_path},
             $package,
@@ -565,7 +565,7 @@ sub stow_node {
         );
     }
     else {
-        $self->do_link($source, $real_target);
+        $self->do_link($source, $target);
     }
     return;
 }
@@ -750,29 +750,29 @@ sub unstow_contents {
     my $self = shift;
     my ($stow_path, $package, $package_target) = @_;
 
-    my $real_target = $package_target;
+    my $target = $package_target;
 
     if ($self->{dotfiles}) {
-        $real_target = adjust_dotfile($package_target);
+        $target = adjust_dotfile($package_target);
     }
 
     my $path = join_paths($stow_path, $package, $package_target);
 
-    return if $self->should_skip_target_which_is_stow_dir($real_target);
+    return if $self->should_skip_target_which_is_stow_dir($target);
 
     my $cwd = getcwd();
-    my $msg = "Unstowing from $real_target (cwd=$cwd, stow dir=$self->{stow_path})";
+    my $msg = "Unstowing from $target (cwd=$cwd, stow dir=$self->{stow_path})";
     $msg =~ s!$ENV{HOME}/!~/!g;
     debug(3, $msg);
     debug(4, "  source path is $path");
     # We traverse the source tree not the target tree, so $path must exist.
     error("unstow_contents() called with non-directory path: $path")
         unless -d $path;
-    # When called at the top level, $real_target should exist.  And
+    # When called at the top level, $target should exist.  And
     # unstow_node() should only call this via mutual recursion if
-    # $real_target exists.
-    error("unstow_contents() called with invalid target: $real_target")
-        unless $self->is_a_node($real_target);
+    # $target exists.
+    error("unstow_contents() called with invalid target: $target")
+        unless $self->is_a_node($target);
 
     opendir my $DIR, $path
         or error("cannot read directory: $path ($!)");
@@ -788,8 +788,8 @@ sub unstow_contents {
 
         $self->unstow_node($stow_path, $package, $node_target);
     }
-    if (-d $real_target) {
-        $self->cleanup_invalid_links($real_target);
+    if (-d $target) {
+        $self->cleanup_invalid_links($target);
     }
 }
 
@@ -808,50 +808,50 @@ sub unstow_node {
     my $self = shift;
     my ($stow_path, $package, $package_target) = @_;
 
-    my $real_target = $package_target;
+    my $target = $package_target;
 
     if ($self->{dotfiles}) {
-        $real_target = adjust_dotfile($package_target);
+        $target = adjust_dotfile($package_target);
     }
 
     my $path = join_paths($stow_path, $package, $package_target);
 
     debug(3, "Unstowing $path");
-    debug(4, "  target is $real_target");
+    debug(4, "  target is $target");
 
     # Does the target exist?
-    if ($self->is_a_link($real_target)) {
-        debug(4, "  Evaluate existing link: $real_target");
+    if ($self->is_a_link($target)) {
+        debug(4, "  Evaluate existing link: $target");
 
         # Where is the link pointing?
-        my $existing_source = $self->read_a_link($real_target);
+        my $existing_source = $self->read_a_link($target);
         if (not $existing_source) {
-            error("Could not read link: $real_target");
+            error("Could not read link: $target");
         }
 
         if ($existing_source =~ m{\A/}) {
-            warn "Ignoring an absolute symlink: $real_target => $existing_source\n";
+            warn "Ignoring an absolute symlink: $target => $existing_source\n";
             return; # XXX #
         }
 
         # Does it point to a node under any stow directory?
         my ($existing_path, $existing_stow_path, $existing_package) =
-            $self->find_stowed_path($real_target, $existing_source);
+            $self->find_stowed_path($target, $existing_source);
         if (not $existing_path) {
              $self->conflict(
                  'unstow',
                  $package,
-                 "existing target is not owned by stow: $real_target => $existing_source"
+                 "existing target is not owned by stow: $target => $existing_source"
              );
             return; # XXX #
         }
 
-        # Does the existing $real_target actually point to anything?
+        # Does the existing $target actually point to anything?
         if (-e $existing_path) {
             # Does link points to the right place?
 
             if ($existing_path eq $path) {
-                $self->do_unlink($real_target);
+                $self->do_unlink($target);
             }
 
             # XXX we quietly ignore links that are stowed to a different
@@ -875,16 +875,16 @@ sub unstow_node {
         }
         else {
             debug(2, "--- removing invalid link into a stow directory: $path");
-            $self->do_unlink($real_target);
+            $self->do_unlink($target);
         }
     }
-    elsif (-e $real_target) {
-        debug(4, "  Evaluate existing node: $real_target");
-        if (-d $real_target) {
+    elsif (-e $target) {
+        debug(4, "  Evaluate existing node: $target");
+        if (-d $target) {
             $self->unstow_contents($stow_path, $package, $package_target);
 
             # This action may have made the parent directory foldable
-            if (my $parent = $self->foldable($real_target)) {
+            if (my $parent = $self->foldable($target)) {
                 $self->fold_tree($package_target, $parent);
             }
         }
@@ -892,12 +892,12 @@ sub unstow_node {
             $self->conflict(
                 'unstow',
                 $package,
-                "existing target is neither a link nor a directory: $real_target",
+                "existing target is neither a link nor a directory: $target",
             );
         }
     }
     else {
-        debug(2, "$real_target did not exist to be unstowed");
+        debug(2, "$target did not exist to be unstowed");
     }
     return;
 }

--- a/lib/Stow.pm.in
+++ b/lib/Stow.pm.in
@@ -748,25 +748,31 @@ sub unstow_node_orig {
 #============================================================================
 sub unstow_contents {
     my $self = shift;
-    my ($stow_path, $package, $target) = @_;
+    my ($stow_path, $package, $package_target) = @_;
 
-    my $path = join_paths($stow_path, $package, $target);
+    my $real_target = $package_target;
 
-    return if $self->should_skip_target_which_is_stow_dir($target);
+    if ($self->{dotfiles}) {
+        $real_target = adjust_dotfile($package_target);
+    }
+
+    my $path = join_paths($stow_path, $package, $package_target);
+
+    return if $self->should_skip_target_which_is_stow_dir($real_target);
 
     my $cwd = getcwd();
-    my $msg = "Unstowing from $target (cwd=$cwd, stow dir=$self->{stow_path})";
+    my $msg = "Unstowing from $real_target (cwd=$cwd, stow dir=$self->{stow_path})";
     $msg =~ s!$ENV{HOME}/!~/!g;
     debug(3, $msg);
     debug(4, "  source path is $path");
     # We traverse the source tree not the target tree, so $path must exist.
     error("unstow_contents() called with non-directory path: $path")
         unless -d $path;
-    # When called at the top level, $target should exist.  And
+    # When called at the top level, $real_target should exist.  And
     # unstow_node() should only call this via mutual recursion if
-    # $target exists.
-    error("unstow_contents() called with invalid target: $target")
-        unless $self->is_a_node($target);
+    # $real_target exists.
+    error("unstow_contents() called with invalid target: $real_target")
+        unless $self->is_a_node($real_target);
 
     opendir my $DIR, $path
         or error("cannot read directory: $path ($!)");
@@ -777,19 +783,13 @@ sub unstow_contents {
     for my $node (@listing) {
         next NODE if $node eq '.';
         next NODE if $node eq '..';
-        my $node_target = join_paths($target, $node);
+        my $node_target = join_paths($package_target, $node);
         next NODE if $self->ignore($stow_path, $package, $node_target);
-
-        if ($self->{dotfiles}) {
-            my $adj_node_target = adjust_dotfile($node_target);
-            debug(4, "  Adjusting: $node_target => $adj_node_target");
-            $node_target = $adj_node_target;
-        }
 
         $self->unstow_node($stow_path, $package, $node_target);
     }
-    if (-d $target) {
-        $self->cleanup_invalid_links($target);
+    if (-d $real_target) {
+        $self->cleanup_invalid_links($real_target);
     }
 }
 
@@ -806,51 +806,52 @@ sub unstow_contents {
 #============================================================================
 sub unstow_node {
     my $self = shift;
-    my ($stow_path, $package, $target) = @_;
+    my ($stow_path, $package, $package_target) = @_;
 
-    my $path = join_paths($stow_path, $package, $target);
+    my $real_target = $package_target;
+
+    if ($self->{dotfiles}) {
+        $real_target = adjust_dotfile($package_target);
+    }
+
+    my $path = join_paths($stow_path, $package, $package_target);
 
     debug(3, "Unstowing $path");
-    debug(4, "  target is $target");
+    debug(4, "  target is $real_target");
 
     # Does the target exist?
-    if ($self->is_a_link($target)) {
-        debug(4, "  Evaluate existing link: $target");
+    if ($self->is_a_link($real_target)) {
+        debug(4, "  Evaluate existing link: $real_target");
 
         # Where is the link pointing?
-        my $existing_source = $self->read_a_link($target);
+        my $existing_source = $self->read_a_link($real_target);
         if (not $existing_source) {
-            error("Could not read link: $target");
+            error("Could not read link: $real_target");
         }
 
         if ($existing_source =~ m{\A/}) {
-            warn "Ignoring an absolute symlink: $target => $existing_source\n";
+            warn "Ignoring an absolute symlink: $real_target => $existing_source\n";
             return; # XXX #
         }
 
         # Does it point to a node under any stow directory?
         my ($existing_path, $existing_stow_path, $existing_package) =
-            $self->find_stowed_path($target, $existing_source);
+            $self->find_stowed_path($real_target, $existing_source);
         if (not $existing_path) {
              $self->conflict(
                  'unstow',
                  $package,
-                 "existing target is not owned by stow: $target => $existing_source"
+                 "existing target is not owned by stow: $real_target => $existing_source"
              );
             return; # XXX #
         }
 
-        # Does the existing $target actually point to anything?
+        # Does the existing $real_target actually point to anything?
         if (-e $existing_path) {
             # Does link points to the right place?
 
-            # Adjust for dotfile if necessary.
-            if ($self->{dotfiles}) {
-                $existing_path = adjust_dotfile($existing_path);
-            }
-
             if ($existing_path eq $path) {
-                $self->do_unlink($target);
+                $self->do_unlink($real_target);
             }
 
             # XXX we quietly ignore links that are stowed to a different
@@ -874,29 +875,29 @@ sub unstow_node {
         }
         else {
             debug(2, "--- removing invalid link into a stow directory: $path");
-            $self->do_unlink($target);
+            $self->do_unlink($real_target);
         }
     }
-    elsif (-e $target) {
-        debug(4, "  Evaluate existing node: $target");
-        if (-d $target) {
-            $self->unstow_contents($stow_path, $package, $target);
+    elsif (-e $real_target) {
+        debug(4, "  Evaluate existing node: $real_target");
+        if (-d $real_target) {
+            $self->unstow_contents($stow_path, $package, $package_target);
 
             # This action may have made the parent directory foldable
-            if (my $parent = $self->foldable($target)) {
-                $self->fold_tree($target, $parent);
+            if (my $parent = $self->foldable($real_target)) {
+                $self->fold_tree($package_target, $parent);
             }
         }
         else {
             $self->conflict(
                 'unstow',
                 $package,
-                "existing target is neither a link nor a directory: $target",
+                "existing target is neither a link nor a directory: $real_target",
             );
         }
     }
     else {
-        debug(2, "$target did not exist to be unstowed");
+        debug(2, "$real_target did not exist to be unstowed");
     }
     return;
 }

--- a/lib/Stow.pm.in
+++ b/lib/Stow.pm.in
@@ -367,11 +367,18 @@ sub within_target_do {
 #============================================================================
 sub stow_contents {
     my $self = shift;
-    my ($stow_path, $package, $target, $source) = @_;
+    my ($stow_path, $package, $package_target, $source) = @_;
 
-    my $path = join_paths($stow_path, $package, $target);
+    my $real_target = $package_target;
 
-    return if $self->should_skip_target_which_is_stow_dir($target);
+    if ($self->{dotfiles}) {
+        debug(4, "  Adjusting: $package_target => $real_target");
+        $real_target = adjust_dotfile($package_target);
+    }
+
+    my $path = join_paths($stow_path, $package, $package_target);
+
+    return if $self->should_skip_target_which_is_stow_dir($real_target);
 
     my $cwd = getcwd();
     my $msg = "Stowing contents of $path (cwd=$cwd)";
@@ -381,8 +388,8 @@ sub stow_contents {
 
     error("stow_contents() called with non-directory path: $path")
         unless -d $path;
-    error("stow_contents() called with non-directory target: $target")
-        unless $self->is_a_node($target);
+    error("stow_contents() called with non-directory target: $real_target")
+        unless $self->is_a_node($real_target);
 
     opendir my $DIR, $path
         or error("cannot read directory: $path ($!)");
@@ -393,14 +400,8 @@ sub stow_contents {
     for my $node (@listing) {
         next NODE if $node eq '.';
         next NODE if $node eq '..';
-        my $node_target = join_paths($target, $node);
+        my $node_target = join_paths($package_target, $node);
         next NODE if $self->ignore($stow_path, $package, $node_target);
-
-        if ($self->{dotfiles}) {
-            my $adj_node_target = adjust_dotfile($node_target);
-            debug(4, "  Adjusting: $node_target => $adj_node_target");
-            $node_target = $adj_node_target;
-        }
 
         $self->stow_node(
             $stow_path,
@@ -429,11 +430,18 @@ sub stow_contents {
 #============================================================================
 sub stow_node {
     my $self = shift;
-    my ($stow_path, $package, $target, $source) = @_;
+    my ($stow_path, $package, $package_target, $source) = @_;
 
-    my $path = join_paths($stow_path, $package, $target);
+    my $real_target = $package_target;
 
-    debug(3, "Stowing $stow_path / $package / $target");
+    if ($self->{dotfiles}) {
+        debug(4, "  Adjusting: $package_target => $real_target");
+        $real_target = adjust_dotfile($package_target);
+    }
+
+    my $path = join_paths($stow_path, $package, $package_target);
+
+    debug(3, "Stowing $stow_path / $package / $package_target");
     debug(4, "  => $source");
 
     # Don't try to stow absolute symlinks (they can't be unstowed)
@@ -451,59 +459,59 @@ sub stow_node {
     }
 
     # Does the target already exist?
-    if ($self->is_a_link($target)) {
+    if ($self->is_a_link($real_target)) {
         # Where is the link pointing?
-        my $existing_source = $self->read_a_link($target);
+        my $existing_source = $self->read_a_link($real_target);
         if (not $existing_source) {
-            error("Could not read link: $target");
+            error("Could not read link: $real_target");
         }
-        debug(4, "  Evaluate existing link: $target => $existing_source");
+        debug(4, "  Evaluate existing link: $real_target => $existing_source");
 
         # Does it point to a node under any stow directory?
         my ($existing_path, $existing_stow_path, $existing_package) =
-            $self->find_stowed_path($target, $existing_source);
+            $self->find_stowed_path($real_target, $existing_source);
         if (not $existing_path) {
             $self->conflict(
                 'stow',
                 $package,
-                "existing target is not owned by stow: $target"
+                "existing target is not owned by stow: $real_target"
             );
             return; # XXX #
         }
 
-        # Does the existing $target actually point to anything?
+        # Does the existing $real_target actually point to anything?
         if ($self->is_a_node($existing_path)) {
             if ($existing_source eq $source) {
-                debug(2, "--- Skipping $target as it already points to $source");
+                debug(2, "--- Skipping $real_target as it already points to $source");
             }
-            elsif ($self->defer($target)) {
-                debug(2, "--- Deferring installation of: $target");
+            elsif ($self->defer($real_target)) {
+                debug(2, "--- Deferring installation of: $real_target");
             }
-            elsif ($self->override($target)) {
-                debug(2, "--- Overriding installation of: $target");
-                $self->do_unlink($target);
-                $self->do_link($source, $target);
+            elsif ($self->override($real_target)) {
+                debug(2, "--- Overriding installation of: $real_target");
+                $self->do_unlink($real_target);
+                $self->do_link($source, $real_target);
             }
-            elsif ($self->is_a_dir(join_paths(parent($target), $existing_source)) &&
-                   $self->is_a_dir(join_paths(parent($target), $source))     ) {
+            elsif ($self->is_a_dir(join_paths(parent($real_target), $existing_source)) &&
+                   $self->is_a_dir(join_paths(parent($real_target), $source))     ) {
 
                 # If the existing link points to a directory,
                 # and the proposed new link points to a directory,
                 # then we can unfold (split open) the tree at that point
 
-                debug(2, "--- Unfolding $target which was already owned by $existing_package");
-                $self->do_unlink($target);
-                $self->do_mkdir($target);
+                debug(2, "--- Unfolding $real_target which was already owned by $existing_package");
+                $self->do_unlink($real_target);
+                $self->do_mkdir($real_target);
                 $self->stow_contents(
                     $existing_stow_path,
                     $existing_package,
-                    $target,
+                    $package_target,
                     join_paths('..', $existing_source),
                 );
                 $self->stow_contents(
                     $self->{stow_path},
                     $package,
-                    $target,
+                    $package_target,
                     join_paths('..', $source),
                 );
             }
@@ -512,52 +520,52 @@ sub stow_node {
                     'stow',
                     $package,
                     "existing target is stowed to a different package: "
-                    . "$target => $existing_source"
+                    . "$real_target => $existing_source"
                 );
             }
         }
         else {
             # The existing link is invalid, so replace it with a good link
             debug(2, "--- replacing invalid link: $path");
-            $self->do_unlink($target);
-            $self->do_link($source, $target);
+            $self->do_unlink($real_target);
+            $self->do_link($source, $real_target);
         }
     }
-    elsif ($self->is_a_node($target)) {
-        debug(4, "  Evaluate existing node: $target");
-        if ($self->is_a_dir($target)) {
+    elsif ($self->is_a_node($real_target)) {
+        debug(4, "  Evaluate existing node: $real_target");
+        if ($self->is_a_dir($real_target)) {
             $self->stow_contents(
                 $self->{stow_path},
                 $package,
-                $target,
+                $package_target,
                 join_paths('..', $source),
             );
         }
         else {
             if ($self->{adopt}) {
-                $self->do_mv($target, $path);
-                $self->do_link($source, $target);
+                $self->do_mv($real_target, $path);
+                $self->do_link($source, $real_target);
             }
             else {
                 $self->conflict(
                     'stow',
                     $package,
-                    "existing target is neither a link nor a directory: $target"
+                    "existing target is neither a link nor a directory: $real_target"
                 );
             }
         }
     }
     elsif ($self->{'no-folding'} && -d $path && ! -l $path) {
-        $self->do_mkdir($target);
+        $self->do_mkdir($real_target);
         $self->stow_contents(
             $self->{stow_path},
             $package,
-            $target,
+            $package_target,
             join_paths('..', $source),
         );
     }
     else {
-        $self->do_link($source, $target);
+        $self->do_link($source, $real_target);
     }
     return;
 }

--- a/t/dotfiles.t
+++ b/t/dotfiles.t
@@ -24,7 +24,7 @@ use warnings;
 
 use testutil;
 
-use Test::More tests => 8;
+use Test::More tests => 9;
 use English qw(-no_match_vars);
 
 use testutil;
@@ -149,10 +149,23 @@ is(
 );
 
 #
-# package containing a dot dir, no folding
+# unstow from existing directory
 #
 
-remove_link('.config/emacs');
+$stow = new_Stow(dir => '../stow', dotfiles => 1);
+
+$stow->plan_unstow('emacs');
+$stow->process_tasks();
+ok(
+    $stow->get_conflict_count == 0 &&
+    -d '.config' && ! -e '.config/stow' &&
+    -f '../stow/emacs/dot-config/emacs/init.el'
+    => 'unstow from a directory'
+);
+
+#
+# package containing a dot dir, no folding
+#
 
 $stow = new_Stow(dir => '../stow', dotfiles => 1, 'no-folding' => 1);
 

--- a/t/dotfiles.t
+++ b/t/dotfiles.t
@@ -24,7 +24,7 @@ use warnings;
 
 use testutil;
 
-use Test::More tests => 6;
+use Test::More tests => 8;
 use English qw(-no_match_vars);
 
 use testutil;
@@ -128,4 +128,41 @@ ok(
     $stow->get_conflict_count == 0 &&
     -f '../stow/dotfiles/dot-bar' && ! -e '.bar'
     => 'unstow a simple dotfile'
+);
+
+#
+# stow into existing directory
+#
+
+$stow = new_Stow(dir => '../stow', dotfiles => 1);
+
+make_path('.config');
+make_path('../stow/emacs/dot-config/emacs');
+make_file('../stow/emacs/dot-config/emacs/init.el');
+
+$stow->plan_stow('emacs');
+$stow->process_tasks();
+is(
+    readlink('.config/emacs'),
+    '../../stow/emacs/dot-config/emacs',
+    => 'processed dotfile folder into existing folder'
+);
+
+#
+# package containing a dot dir, no folding
+#
+
+remove_link('.config/emacs');
+
+$stow = new_Stow(dir => '../stow', dotfiles => 1, 'no-folding' => 1);
+
+make_path('../stow/emacs/dot-config/emacs');
+make_file('../stow/emacs/dot-config/emacs/init.el');
+
+$stow->plan_stow('emacs');
+$stow->process_tasks();
+is(
+    readlink('.config/emacs/init.el'),
+    '../../../stow/emacs/dot-config/emacs/init.el',
+    => 'processed dotfile folder without folding'
 );


### PR DESCRIPTION
This is obviously a lot more invasive than the original approach, so I'm not sure if it's acceptable, but it's probably necessary to fix #33. I'm not really happy about having to repeatedly adjust the target in each new call to stow_contents and stow_node. Perhaps it would be better to pass `$package_target` and `$target` as separate arguments?