### PR TITLE
fix dotfile "dot-" directory handling bug #33 and #56727

### DIFF
--- a/lib/Stow.pm.in
+++ b/lib/Stow.pm.in
@@ -379,6 +379,13 @@ sub stow_contents {
     debug(3, $msg);
     debug(4, "  => $source");
 
+    if($self->{dotfiles}) {
+        my $alt_target = $target;
+        $alt_target =~s/\./dot-/;
+        $path = join_paths($stow_path, $package, $alt_target)
+            unless -d $path;
+    }
+    
     error("stow_contents() called with non-directory path: $path")
         unless -d $path;
     error("stow_contents() called with non-directory target: $target")


### PR DESCRIPTION
fix GitHub bug #33 and GNU [ #56727 ](https://savannah.gnu.org/bugs/?56727) by attempting to restore target $path with regex if it doesn't exist.
Might slightly slow the process down, as it's now checking the directory twice every single stow_contents() call, but it's the least intrusive fix i could come up with. 