### PR TITLE
fix dockerfile apt-get without force-yes

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -19,7 +19,7 @@
 FROM debian:bookworm
 RUN DEBIAN_FRONTEND=noninteractive apt-get update -qq
 RUN DEBIAN_FRONTEND=noninteractive \
-apt-get install -y -q \
+apt-get install -y --force-yes -q \
     autoconf \
     bzip2 \
     cpanminus \


### PR DESCRIPTION
This patch fixes the return error 100 that currently happens when trying to run the build script with docker.

```bash
E: There are problems and -y was used without --force-yes
The command '/bin/sh -c DEBIAN_FRONTEND=noninteractive apt-get update -qq && apt-get install -y -q autoconf bzip2 cpanminus gawk git libssl-dev make patch perlbrew texinfo texlive texi2html && apt-get clean && rm -rf /var/lib/apt/lists/*'
returned a non-zero code: 100
```