### PR TITLE
avoid precedence warning

### DIFF
--- a/bin/stow.in
+++ b/bin/stow.in
@@ -837,7 +837,7 @@ Report bugs to: bug-stow\@gnu.org
 Stow home page: <http://www.gnu.org/software/stow/>
 General help using GNU software: <http://www.gnu.org/gethelp/>
 EOT
-    exit defined $msg ? 1 : 0;
+    exit (defined $msg ? 1 : 0);
 }
 
 sub version {


### PR DESCRIPTION
Perl 5.40.0 extended the scope of the precedence warning to include ternary operators.

<https://perldoc.perl.org/5.40.0/perldelta>