### PR TITLE
Reposition Stow according to its primary use case

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -5,11 +5,17 @@ code in this repository.
 
 ## Overview
 
-GNU Stow is a symlink farm manager written in Perl. It manages the
-installation of software packages by creating symlinks from a target
-directory (e.g., `/usr/local`) to package directories within a stow
-directory (e.g., `/usr/local/stow/package`). This allows multiple
-packages to coexist without file conflicts.
+GNU Stow is a dotfile organizer written in Perl. It keeps your
+configuration files in separate directories, then uses symlink tree
+mirroring to make them appear installed in your home directory (or any
+target directory).
+
+Stow is primarily used for managing dotfiles and configuration files
+(e.g. organizing `~/dotfiles/vim` and `~/dotfiles/zsh` with symlinks
+for `~/.vimrc`, `~/.zshrc`, etc.), but can also manage software
+package installations by creating symlinks from a target directory
+(e.g. `/usr/local`) to package directories within a stow directory
+(e.g. `/usr/local/stow/package`).
 
 The codebase consists of:
 
@@ -24,6 +30,7 @@ The codebase consists of:
 `Makefile` before execution.**
 
 Before testing any code changes:
+
 1. Modify the `.in` files (NOT the generated files)
 2. Run `make` to regenerate the preprocessed versions
 3. Then test your changes

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -12,7 +12,7 @@ target directory).
 
 Stow is primarily used for managing dotfiles and configuration files
 (e.g. organizing `~/dotfiles/vim` and `~/dotfiles/zsh` with symlinks
-for `~/.vimrc`, `~/.zshrc`, etc.), but can also manage software
+at `~/.vimrc`, `~/.zshrc`, etc.), but can also manage software
 package installations by creating symlinks from a target directory
 (e.g. `/usr/local`) to package directories within a stow directory
 (e.g. `/usr/local/stow/package`).

--- a/META.json
+++ b/META.json
@@ -1,5 +1,5 @@
 {
-   "abstract" : "manage farms of symbolic links",
+   "abstract" : "organize dotfiles and configuration files",
    "author" : [
       "unknown"
    ],

--- a/META.yml
+++ b/META.yml
@@ -1,5 +1,5 @@
 ---
-abstract: 'manage farms of symbolic links'
+abstract: 'organize dotfiles and configuration files'
 author:
   - unknown
 build_requires:

--- a/README.md
+++ b/README.md
@@ -8,10 +8,9 @@ This README describes GNU Stow.  This is not the definitive
 documentation for Stow; for that, see the [info
 manual](https://www.gnu.org/software/stow/manual/).
 
-Stow is a symlink farm manager program which takes distinct sets
-of software and/or data located in separate directories on the
-filesystem, and makes them all appear to be installed in a single
-directory tree.
+Stow is a dotfile organizer which keeps your configuration files
+in separate directories, then uses symlink tree mirroring to make
+them appear installed in your home directory (or any target directory).
 
 Originally Stow was born to address the need to administer, upgrade,
 install, and remove files in independent software packages without
@@ -37,12 +36,13 @@ package managers such as Ruby's
 Javascript's [`npm`](https://en.wikipedia.org/wiki/Npm_(software)),
 and so on.
 
-However Stow is still used not only for software package management,
-but also for other purposes, such as facilitating [a more controlled
-approach to management of configuration files in the user's home
+Today, Stow is primarily used for [managing configuration files
+(dotfiles) in the user's home
 directory](http://brandon.invergo.net/news/2012-05-26-using-gnu-stow-to-manage-your-dotfiles.html),
 especially when [coupled with version control
-systems](http://lists.gnu.org/archive/html/info-stow/2011-12/msg00000.html).
+systems](http://lists.gnu.org/archive/html/info-stow/2011-12/msg00000.html)
+such as git.  However, it can also still be used for managing software
+package installations as originally intended.
 
 Stow is implemented as a combination of a Perl script providing a CLI
 interface, and a backend Perl module which does most of the work.

--- a/bin/stow.in
+++ b/bin/stow.in
@@ -1,6 +1,6 @@
 #!@PERL@
 
-# GNU Stow - manage farms of symbolic links
+# GNU Stow - organize dotfiles and configuration files
 # Copyright (C) 1993, 1994, 1995, 1996 by Bob Glickstein
 # Copyright (C) 2000, 2001 Guillaume Morin
 # Copyright (C) 2007 Kahlil Hodgson
@@ -23,7 +23,7 @@
 
 =head1 NAME
 
-stow - manage farms of symbolic links
+stow - organize dotfiles and configuration files
 
 =head1 SYNOPSIS
 
@@ -35,30 +35,27 @@ This manual page describes GNU Stow @VERSION@.  This is not the
 definitive documentation for Stow; for that, see the accompanying info
 manual, e.g. by typing C<info stow>.
 
-Stow is a symlink farm manager which takes distinct sets of software
-and/or data located in separate directories on the filesystem, and
-makes them all appear to be installed in a single directory tree.
+Stow is primarily used for managing dotfiles and configuration files
+in the user's home directory, especially when coupled with version
+control systems such as git. By organizing application configuration
+in separate directories (e.g. F<~/dotfiles/vim>, F<~/dotfiles/zsh>),
+Stow uses symlink tree mirroring to make them appear installed in
+their expected locations (F<~/.vimrc>, F<~/.zshrc>, etc.).
 
 Originally Stow was born to address the need to administer, upgrade,
 install, and remove files in independent software packages without
 confusing them with other files sharing the same file system space.
-For instance, many years ago it used to be common to compile programs
-such as Perl and Emacs from source.  By using Stow, F</usr/local/bin>
-could contain symlinks to files within F</usr/local/stow/emacs/bin>,
-F</usr/local/stow/perl/bin> etc., and likewise recursively for any
-other subdirectories such as F<.../share>, F<.../man>, and so on.
+For instance, it used to be common to compile programs such as Perl
+and Emacs from source and install them in F</usr/local>. By using
+Stow, F</usr/local/bin> could contain symlinks to files within
+F</usr/local/stow/emacs/bin>, F</usr/local/stow/perl/bin> etc.,
+and likewise recursively for any other subdirectories.
 
-While this is useful for keeping track of system-wide and per-user
-installations of software built from source, in more recent times
-software packages are often managed by more sophisticated package
-management software such as rpm, dpkg, and Nix / GNU Guix, or
-language-native package managers such as Ruby's gem, Python's pip,
-Javascript's npm, and so on.
-
-However Stow is still used not only for software package management,
-but also for other purposes, such as facilitating a more controlled
-approach to management of configuration files in the user's home
-directory, especially when coupled with version control systems.
+While modern software packages are typically managed by more
+sophisticated package management software such as rpm, dpkg, and
+Nix / GNU Guix, or language-native package managers such as Ruby's
+gem, Python's pip, Javascript's npm, and so on, Stow can still be
+used for managing directory-based software installations if needed.
 
 Stow was inspired by Carnegie Mellon's Depot program, but is
 substantially simpler and safer. Whereas Depot required database files

--- a/doc/stow.texi
+++ b/doc/stow.texi
@@ -15,7 +15,7 @@
 
 @copying
 This manual describes GNU Stow version @value{VERSION}
-(@value{UPDATED}), a program for managing farms of symbolic links.
+(@value{UPDATED}), a program for organizing dotfiles and configuration files.
 
 Software and documentation is copyrighted by the following:
 
@@ -61,7 +61,7 @@ approved by the Free Software Foundation.
 @c ===========================================================================
 @titlepage
 @title Stow @value{VERSION}
-@subtitle Managing the installation of software packages
+@subtitle Organize your dotfiles and configuration files
 @author Bob Glickstein, Zanshin Software, Inc.
 @author Kahlil Hodgson, RMIT University, Australia.
 @author Guillaume Morin
@@ -82,9 +82,9 @@ approved by the Free Software Foundation.
 @top
 
 This manual describes GNU Stow @value{VERSION} (@value{UPDATED}), a
-symlink farm manager which takes distinct sets of software and/or data
-located in separate directories on the filesystem, and makes them
-appear to be installed in a single directory tree.
+dotfile organizer which keeps your configuration files in separate
+directories, then uses symlink tree mirroring to make them appear
+installed in your home directory (or any target directory).
 @end ifnottex
 
 @menu
@@ -129,51 +129,56 @@ Advice on changing compilation and installation parameters
 @node Introduction, Terminology, Top, Top
 @chapter Introduction
 
-GNU Stow is a symlink farm manager which takes distinct sets of
-software and/or data located in separate directories on the
-filesystem, and makes them all appear to be installed in a single
-directory tree.
+GNU Stow allows you to keep dotfiles and configuration files in separate
+directories, and then use symlink tree mirroring to make them appear
+installed in your home directory (or any target directory).
+
+This is particularly useful when those separate directories are tracked
+via a version control system such as @command{git}.@footnote{@uref{http://lists.gnu.org/archive/html/info-stow/2011-12/msg00000.html}}
+
+For example, you might organize your configuration files like this:
+
+@example
+~/dotfiles/vim/.vimrc
+~/dotfiles/vim/.vim/
+~/dotfiles/zsh/.zshrc
+~/dotfiles/zsh/.zshenv
+~/dotfiles/git/.gitconfig
+@end example
+
+@noindent
+By running @command{stow} from @file{~/dotfiles}, these files are
+symlinked to appear in your home directory at @file{~/.vimrc},
+@file{~/.vim/}, @file{~/.zshrc}, and so on.  Each application's
+configuration stays neatly organized in its own directory, making it
+easy to track with version control, yet the files appear exactly where
+the applications expect them.
+
+The approach used by Stow is to mirror each package's directory tree
+using symbolic links.  The structure of each private tree reflects the
+desired structure in the target directory (typically the home
+directory).  Stow creates symlinks that make it appear as though the
+files are installed directly in the target tree, while administration
+can be performed in each package's private tree in isolation from other
+packages.
 
 Originally Stow was born to address the need to administer, upgrade,
 install, and remove files in independent software packages without
 confusing them with other files sharing the same file system space.
 For instance, many years ago it used to be common to compile programs
 such as Perl and Emacs from source and install them in
-@file{/usr/local}.  When one does so, one winds up with the following
-files@footnote{As of Perl 4.036 and Emacs 19.22.  These are now
-ancient releases but the example still holds valid.} in
-@file{/usr/local/man/man1}:
+@file{/usr/local}.  When one does so, one winds up with files from
+multiple packages mixed together in directories like
+@file{/usr/local/man/man1}.
 
-@example
-a2p.1
-ctags.1
-emacs.1
-etags.1
-h2ph.1
-perl.1
-s2p.1
-@end example
+By using Stow with a stow directory like @file{/usr/local/stow},
+@file{/usr/local/bin} could contain symlinks to files within
+@file{/usr/local/stow/emacs/bin}, @file{/usr/local/stow/perl/bin},
+etc., keeping each package separate while making them appear installed
+in @file{/usr/local}.
 
-@noindent
-Now suppose it's time to uninstall Perl.  Which man pages
-get removed?  Obviously @file{perl.1} is one of them, but it should not
-be the administrator's responsibility to memorize the ownership of
-individual files by separate packages.
-
-The approach used by Stow is to install each package into its own
-tree, then use symbolic links to make it appear as though the files are
-installed in the common tree.  Administration can be performed in the
-package's private tree in isolation from clutter from other packages.
-Stow can then be used to update the symbolic links.  The structure
-of each private tree should reflect the desired structure in the common
-tree; i.e. (in the typical case) there should be a @file{bin} directory
-containing executables, a @file{man/man1} directory containing section 1
-man pages, and so on.
-
-While this is useful for keeping track of system-wide and per-user
-installations of software built from source, in more recent times
-software packages are often managed by more sophisticated package
-management software such as
+However these days software on modern systems is typically managed by
+more sophisticated package management software such as
 @uref{https://en.wikipedia.org/wiki/Rpm_(software), @command{rpm}},
 @uref{https://en.wikipedia.org/wiki/Dpkg, @command{dpkg}}, and
 @uref{https://en.wikipedia.org/wiki/Nix_package_manager, Nix} /
@@ -184,12 +189,14 @@ language-native package managers such as
 @command{pip}}, @uref{https://en.wikipedia.org/wiki/Npm_(software),
 Javascript's @command{npm}}, and so on.
 
-However Stow is still used not only for software package management,
-but also for other purposes, such as facilitating a more controlled
-approach to management of configuration files in the user's home
+So today Stow is primarily used for managing dotfiles and configuration
+files in the user's home
 directory@footnote{@uref{http://brandon.invergo.net/news/2012-05-26-using-gnu-stow-to-manage-your-dotfiles.html}},
-especially when coupled with version control
-systems@footnote{@uref{http://lists.gnu.org/archive/html/info-stow/2011-12/msg00000.html}}.
+especially when coupled with a version control system such as
+@command{git}.
+
+But Stow can still be used for managing directory-based software
+installations if needed.
 
 Stow was inspired by Carnegie Mellon's Depot program, but is
 substantially simpler and safer.  Whereas Depot required database

--- a/lib/Stow.pm.in
+++ b/lib/Stow.pm.in
@@ -19,7 +19,7 @@ package Stow;
 
 =head1 NAME
 
-Stow - manage farms of symbolic links
+Stow - organize dotfiles and configuration files
 
 =head1 SYNOPSIS
 
@@ -33,11 +33,16 @@ Stow - manage farms of symbolic links
 
 =head1 DESCRIPTION
 
-This is the backend Perl module for GNU Stow, a program for managing
-the installation of software packages, keeping them separate
-(C</usr/local/stow/emacs> vs. C</usr/local/stow/perl>, for example)
-while making them appear to be installed in the same place
-(C</usr/local>).
+This is the backend Perl module for GNU Stow, a program for organizing
+dotfiles and configuration files by keeping them in separate directories
+while using symlink tree mirroring to make them appear installed in
+your home directory (or any target directory).
+
+Stow is primarily used for managing dotfiles (e.g. organizing
+C<~/dotfiles/vim> and C<~/dotfiles/zsh> while symlinking them into
+C<~/.vimrc>, C<~/.zshrc>, etc.), but can also manage software package
+installations (e.g. keeping C</usr/local/stow/emacs> and
+C</usr/local/stow/perl> separate while symlinking into C</usr/local>).
 
 Stow doesn't store an extra state between runs, so there's no danger
 of mangling directories when file hierarchies don't match the


### PR DESCRIPTION
I stumbled across a video about Stow which led to finding several
others, as well as several blog posts etc., and was amazed to see the
overwhelming popularity of the dotfiles management use case.

It was also clear that the labelling "symlink farm manager" didn't
resonate well.  So alter the documentation to double down on this use
case in which people clearly find a lot of value, whilst maintaining
the position that there are other use cases, and also not forgetting
the history of Stow's origins.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Documentation
  - Reframed product description from “symlink farm manager” to a “dotfile organizer,” emphasizing symlink mirroring into a home (or target) directory.
  - Clarified usage for managing dotfiles and configuration files, while noting continued support for software installations.
  - Updated examples, terminology, and narrative to focus on dotfiles; added guidance on version control integration.
  - Refreshed manuals and help text for clearer workflows and paths.
  - No functional or API changes; behavior remains the same.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->