### PR TITLE
Have verbosity default to level 1 in simulate mode

### DIFF
--- a/bin/stow.in
+++ b/bin/stow.in
@@ -540,6 +540,10 @@ sub process_options {
         }
     }
 
+    if ($options{simulate} && !exists $options{verbose}) {
+        $options{verbose} = 1;
+    }
+
     # Run checks on the merged options.
     sanitize_path_options(\%options);
     check_packages($pkgs_to_unstow, $pkgs_to_stow);

--- a/t/cli_options.t
+++ b/t/cli_options.t
@@ -22,7 +22,7 @@
 use strict;
 use warnings;
 
-use Test::More tests => 6;
+use Test::More tests => 7;
 
 use testutil;
 
@@ -116,6 +116,25 @@ subtest('no expansion of environment variables', sub {
     my ($options, $pkgs_to_delete, $pkgs_to_stow) = process_options();
     is($options->{target}, "$TEST_DIR/".'$HOME', 'no expansion');
     remove_dir("$TEST_DIR/".'$HOME');
+});
+
+subtest('simulate defaults verbosity unless explicitly set', sub {
+    plan tests => 2;
+
+    local @ARGV = (
+        '--simulate',
+        'dummy'
+    );
+    my ($options, $pkgs_to_delete, $pkgs_to_stow) = process_options();
+    is($options->{verbose}, 1, 'simulate defaults verbosity to 1');
+
+    local @ARGV = (
+        '--simulate',
+        '--verbose=0',
+        'dummy'
+    );
+    ($options, $pkgs_to_delete, $pkgs_to_stow) = process_options();
+    is($options->{verbose}, 0, 'explicit verbosity overrides simulate default');
 });
 
 # vim:ft=perl


### PR DESCRIPTION
Currently, using `stow --simulate <package>` would normally only output:

    WARNING: in simulation mode so not modifying filesystem.

It is generally meant to be used with `--verbose` for some more more comprehensive simulation result.

This Pull Request only brings the *default* verbosity to 1 from the generic 0, but still allows for explicit disabling with `--verbosity=0`.

Also includes some simple test.

Fixes https://github.com/aspiers/stow/issues/82.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Simulation mode (--simulate) now enables verbose output by default for more detailed logging, unless you explicitly set --verbose=0.
* **Tests**
  * Added a CLI options test to verify the simulated default verbosity and that an explicit --verbose=0 overrides it.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->